### PR TITLE
feat: update package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,22 @@
 			"version": "0.17.2",
 			"license": "MIT",
 			"dependencies": {
-				"@kintone/rest-api-client": "^6.0.0",
-				"dotenv": "^17.2.3"
+				"@kintone/rest-api-client": "^6.1.2",
+				"dotenv": "^17.3.1"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.3.6",
-				"@types/node": "^24.10.1",
-				"rimraf": "^6.1.0",
+				"@biomejs/biome": "2.4.6",
+				"@types/node": "^25.4.0",
+				"rimraf": "^6.1.3",
 				"typescript": "^5.9.3",
-				"vite": "^7.2.2",
-				"vitest": "^4.0.10"
+				"vite": "^7.3.1",
+				"vitest": "^4.0.18"
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.6.tgz",
-			"integrity": "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
+			"integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -38,20 +38,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.3.6",
-				"@biomejs/cli-darwin-x64": "2.3.6",
-				"@biomejs/cli-linux-arm64": "2.3.6",
-				"@biomejs/cli-linux-arm64-musl": "2.3.6",
-				"@biomejs/cli-linux-x64": "2.3.6",
-				"@biomejs/cli-linux-x64-musl": "2.3.6",
-				"@biomejs/cli-win32-arm64": "2.3.6",
-				"@biomejs/cli-win32-x64": "2.3.6"
+				"@biomejs/cli-darwin-arm64": "2.4.6",
+				"@biomejs/cli-darwin-x64": "2.4.6",
+				"@biomejs/cli-linux-arm64": "2.4.6",
+				"@biomejs/cli-linux-arm64-musl": "2.4.6",
+				"@biomejs/cli-linux-x64": "2.4.6",
+				"@biomejs/cli-linux-x64-musl": "2.4.6",
+				"@biomejs/cli-win32-arm64": "2.4.6",
+				"@biomejs/cli-win32-x64": "2.4.6"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.6.tgz",
-			"integrity": "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
+			"integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -66,9 +66,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.6.tgz",
-			"integrity": "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
+			"integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
 			"cpu": [
 				"x64"
 			],
@@ -83,13 +83,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.6.tgz",
-			"integrity": "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
+			"integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -100,13 +103,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.6.tgz",
-			"integrity": "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
+			"integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -117,13 +123,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.6.tgz",
-			"integrity": "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
+			"integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -134,13 +143,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.6.tgz",
-			"integrity": "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
+			"integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -151,9 +163,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.6.tgz",
-			"integrity": "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
+			"integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
 			"cpu": [
 				"arm64"
 			],
@@ -168,9 +180,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.6.tgz",
-			"integrity": "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
+			"integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
 			"cpu": [
 				"x64"
 			],
@@ -185,9 +197,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -202,9 +214,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
 			"cpu": [
 				"arm"
 			],
@@ -219,9 +231,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -236,9 +248,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
 			"cpu": [
 				"x64"
 			],
@@ -253,9 +265,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -270,9 +282,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
 			"cpu": [
 				"x64"
 			],
@@ -287,9 +299,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
 			"cpu": [
 				"arm64"
 			],
@@ -304,9 +316,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
 			"cpu": [
 				"x64"
 			],
@@ -321,9 +333,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
 			"cpu": [
 				"arm"
 			],
@@ -338,9 +350,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
 			"cpu": [
 				"arm64"
 			],
@@ -355,9 +367,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
 			"cpu": [
 				"ia32"
 			],
@@ -372,9 +384,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
 			"cpu": [
 				"loong64"
 			],
@@ -389,9 +401,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -406,9 +418,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -423,9 +435,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -440,9 +452,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
 			"cpu": [
 				"s390x"
 			],
@@ -457,9 +469,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
 			"cpu": [
 				"x64"
 			],
@@ -474,9 +486,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
 			"cpu": [
 				"arm64"
 			],
@@ -491,9 +503,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
 			"cpu": [
 				"x64"
 			],
@@ -508,9 +520,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
 			"cpu": [
 				"arm64"
 			],
@@ -525,9 +537,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
 			"cpu": [
 				"x64"
 			],
@@ -542,9 +554,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -559,9 +571,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
 			"cpu": [
 				"x64"
 			],
@@ -576,9 +588,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
 			"cpu": [
 				"arm64"
 			],
@@ -593,9 +605,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -610,9 +622,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
 			"cpu": [
 				"x64"
 			],
@@ -626,47 +638,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -675,17 +646,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@kintone/rest-api-client": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@kintone/rest-api-client/-/rest-api-client-6.0.0.tgz",
-			"integrity": "sha512-Ekf71DhWoiz3sZ8ISS656CqCfCvwBM9GyOlxDcP1u2aK9TANuBpzsKR8O6PcuPMXzGQ3Cm1hg1xfFR+n553T6A==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@kintone/rest-api-client/-/rest-api-client-6.1.2.tgz",
+			"integrity": "sha512-/6RMKD/cNg8KOfQDXLOTzKkfG+EAKuU6czgVF5b5c4Na9uFB9BENmdg7e1eV3qNwszfIt7UpONfT3apCiw2R3Q==",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.12.2",
-				"core-js": "^3.45.1",
-				"form-data": "^4.0.4",
+				"core-js": "^3.46.0",
+				"form-data": "^4.0.5",
 				"js-base64": "^3.7.8",
 				"mime": "^3.0.0",
-				"qs": "^6.14.0"
+				"qs": "^6.14.2"
 			},
 			"engines": {
 				"node": ">=20"
@@ -1000,9 +971,9 @@
 			]
 		},
 		"node_modules/@standard-schema/spec": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1032,26 +1003,26 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.10.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-			"integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+			"version": "25.4.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
+			"integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.10.tgz",
-			"integrity": "sha512-3QkTX/lK39FBNwARCQRSQr0TP9+ywSdxSX+LgbJ2M1WmveXP72anTbnp2yl5fH+dU6SUmBzNMrDHs80G8G2DZg==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.0.10",
-				"@vitest/utils": "4.0.10",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
 				"chai": "^6.2.1",
 				"tinyrainbow": "^3.0.3"
 			},
@@ -1060,13 +1031,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.10.tgz",
-			"integrity": "sha512-e2OfdexYkjkg8Hh3L9NVEfbwGXq5IZbDovkf30qW2tOh7Rh9sVtmSr2ztEXOFbymNxS4qjzLXUQIvATvN4B+lg==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.0.10",
+				"@vitest/spy": "4.0.18",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1087,9 +1058,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.10.tgz",
-			"integrity": "sha512-99EQbpa/zuDnvVjthwz5bH9o8iPefoQZ63WV8+bsRJZNw3qQSvSltfut8yu1Jc9mqOYi7pEbsKxYTi/rjaq6PA==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1100,13 +1071,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.10.tgz",
-			"integrity": "sha512-EXU2iSkKvNwtlL8L8doCpkyclw0mc/t4t9SeOnfOFPyqLmQwuceMPA4zJBa6jw0MKsZYbw7kAn+gl7HxrlB8UQ==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.0.10",
+				"@vitest/utils": "4.0.18",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1114,13 +1085,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.10.tgz",
-			"integrity": "sha512-2N4X2ZZl7kZw0qeGdQ41H0KND96L3qX1RgwuCfy6oUsF2ISGD/HpSbmms+CkIOsQmg2kulwfhJ4CI0asnZlvkg==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.10",
+				"@vitest/pretty-format": "4.0.18",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1129,9 +1100,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.10.tgz",
-			"integrity": "sha512-AsY6sVS8OLb96GV5RoG8B6I35GAbNrC49AO+jNRF9YVGb/g9t+hzNm1H6kD0NDp8tt7VJLs6hb7YMkDXqu03iw==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1139,43 +1110,17 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.10.tgz",
-			"integrity": "sha512-kOuqWnEwZNtQxMKg3WmPK1vmhZu9WcoX69iwWjVz+jvKTsF1emzsv3eoPcDr6ykA3qP2bsCQE7CwqfNtAVzsmg==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.10",
+				"@vitest/pretty-format": "4.0.18",
 				"tinyrainbow": "^3.0.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/assertion-error": {
@@ -1203,6 +1148,29 @@
 				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.4",
 				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -1235,34 +1203,14 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
-			"integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -1287,39 +1235,6 @@
 				"url": "https://opencollective.com/core-js"
 			}
 		},
-		"node_modules/cross-spawn": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1330,9 +1245,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.2.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+			"version": "17.3.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+			"integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -1354,20 +1269,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
@@ -1422,9 +1323,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1435,32 +1336,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.12",
-				"@esbuild/android-arm": "0.25.12",
-				"@esbuild/android-arm64": "0.25.12",
-				"@esbuild/android-x64": "0.25.12",
-				"@esbuild/darwin-arm64": "0.25.12",
-				"@esbuild/darwin-x64": "0.25.12",
-				"@esbuild/freebsd-arm64": "0.25.12",
-				"@esbuild/freebsd-x64": "0.25.12",
-				"@esbuild/linux-arm": "0.25.12",
-				"@esbuild/linux-arm64": "0.25.12",
-				"@esbuild/linux-ia32": "0.25.12",
-				"@esbuild/linux-loong64": "0.25.12",
-				"@esbuild/linux-mips64el": "0.25.12",
-				"@esbuild/linux-ppc64": "0.25.12",
-				"@esbuild/linux-riscv64": "0.25.12",
-				"@esbuild/linux-s390x": "0.25.12",
-				"@esbuild/linux-x64": "0.25.12",
-				"@esbuild/netbsd-arm64": "0.25.12",
-				"@esbuild/netbsd-x64": "0.25.12",
-				"@esbuild/openbsd-arm64": "0.25.12",
-				"@esbuild/openbsd-x64": "0.25.12",
-				"@esbuild/openharmony-arm64": "0.25.12",
-				"@esbuild/sunos-x64": "0.25.12",
-				"@esbuild/win32-arm64": "0.25.12",
-				"@esbuild/win32-ia32": "0.25.12",
-				"@esbuild/win32-x64": "0.25.12"
+				"@esbuild/aix-ppc64": "0.27.3",
+				"@esbuild/android-arm": "0.27.3",
+				"@esbuild/android-arm64": "0.27.3",
+				"@esbuild/android-x64": "0.27.3",
+				"@esbuild/darwin-arm64": "0.27.3",
+				"@esbuild/darwin-x64": "0.27.3",
+				"@esbuild/freebsd-arm64": "0.27.3",
+				"@esbuild/freebsd-x64": "0.27.3",
+				"@esbuild/linux-arm": "0.27.3",
+				"@esbuild/linux-arm64": "0.27.3",
+				"@esbuild/linux-ia32": "0.27.3",
+				"@esbuild/linux-loong64": "0.27.3",
+				"@esbuild/linux-mips64el": "0.27.3",
+				"@esbuild/linux-ppc64": "0.27.3",
+				"@esbuild/linux-riscv64": "0.27.3",
+				"@esbuild/linux-s390x": "0.27.3",
+				"@esbuild/linux-x64": "0.27.3",
+				"@esbuild/netbsd-arm64": "0.27.3",
+				"@esbuild/netbsd-x64": "0.27.3",
+				"@esbuild/openbsd-arm64": "0.27.3",
+				"@esbuild/openbsd-x64": "0.27.3",
+				"@esbuild/openharmony-arm64": "0.27.3",
+				"@esbuild/sunos-x64": "0.27.3",
+				"@esbuild/win32-arm64": "0.27.3",
+				"@esbuild/win32-ia32": "0.27.3",
+				"@esbuild/win32-x64": "0.27.3"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -1519,23 +1420,6 @@
 				"debug": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/form-data": {
@@ -1616,24 +1500,18 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.3.1",
-				"jackspeak": "^4.1.1",
-				"minimatch": "^10.1.1",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^2.0.0"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -1690,39 +1568,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/jackspeak": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/js-base64": {
 			"version": "3.7.8",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
@@ -1730,11 +1575,11 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -1792,37 +1637,30 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
-		},
-		"node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -1855,6 +1693,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1862,20 +1711,10 @@
 			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
-		"node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/path-scurry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -1883,7 +1722,7 @@
 				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -1952,9 +1791,9 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -1967,13 +1806,13 @@
 			}
 		},
 		"node_modules/rimraf": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.0.tgz",
-			"integrity": "sha512-DxdlA1bdNzkZK7JiNWH+BAx1x4tEJWoTofIopFo6qWUU94jYrFZ0ubY05TqH3nWPJ1nKa1JWVFDINZ3fnrle/A==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+			"integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"glob": "^11.0.3",
+				"glob": "^13.0.3",
 				"package-json-from-dist": "^1.0.1"
 			},
 			"bin": {
@@ -2026,29 +1865,6 @@
 				"@rollup/rollup-win32-x64-gnu": "4.53.2",
 				"@rollup/rollup-win32-x64-msvc": "4.53.2",
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/side-channel": {
@@ -2130,19 +1946,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2167,110 +1970,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2279,11 +1978,14 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
@@ -2327,20 +2029,20 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
-			"integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.25.0",
+				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
 				"picomatch": "^4.0.3",
 				"postcss": "^8.5.6",
@@ -2409,28 +2111,28 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.10.tgz",
-			"integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.0.10",
-				"@vitest/mocker": "4.0.10",
-				"@vitest/pretty-format": "4.0.10",
-				"@vitest/runner": "4.0.10",
-				"@vitest/snapshot": "4.0.10",
-				"@vitest/spy": "4.0.10",
-				"@vitest/utils": "4.0.10",
-				"debug": "^4.4.3",
+				"@vitest/expect": "4.0.18",
+				"@vitest/mocker": "4.0.18",
+				"@vitest/pretty-format": "4.0.18",
+				"@vitest/runner": "4.0.18",
+				"@vitest/snapshot": "4.0.18",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
 				"es-module-lexer": "^1.7.0",
 				"expect-type": "^1.2.2",
 				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
 				"picomatch": "^4.0.3",
 				"std-env": "^3.10.0",
 				"tinybench": "^2.9.0",
-				"tinyexec": "^0.3.2",
+				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
 				"tinyrainbow": "^3.0.3",
 				"vite": "^6.0.0 || ^7.0.0",
@@ -2447,12 +2149,12 @@
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
-				"@types/debug": "^4.1.12",
+				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.0.10",
-				"@vitest/browser-preview": "4.0.10",
-				"@vitest/browser-webdriverio": "4.0.10",
-				"@vitest/ui": "4.0.10",
+				"@vitest/browser-playwright": "4.0.18",
+				"@vitest/browser-preview": "4.0.18",
+				"@vitest/browser-webdriverio": "4.0.18",
+				"@vitest/ui": "4.0.18",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},
@@ -2460,7 +2162,7 @@
 				"@edge-runtime/vm": {
 					"optional": true
 				},
-				"@types/debug": {
+				"@opentelemetry/api": {
 					"optional": true
 				},
 				"@types/node": {
@@ -2486,22 +2188,6 @@
 				}
 			}
 		},
-		"node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2514,104 +2200,6 @@
 			},
 			"bin": {
 				"why-is-node-running": "cli.js"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"

--- a/package.json
+++ b/package.json
@@ -43,15 +43,15 @@
 		"test": "vitest --config vite-test.config.ts"
 	},
 	"dependencies": {
-		"@kintone/rest-api-client": "^6.0.0",
-		"dotenv": "^17.2.3"
+		"@kintone/rest-api-client": "^6.1.2",
+		"dotenv": "^17.3.1"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.3.6",
-		"@types/node": "^24.10.1",
-		"rimraf": "^6.1.0",
+		"@biomejs/biome": "2.4.6",
+		"@types/node": "^25.4.0",
+		"rimraf": "^6.1.3",
 		"typescript": "^5.9.3",
-		"vite": "^7.2.2",
-		"vitest": "^4.0.10"
+		"vite": "^7.3.1",
+		"vitest": "^4.0.18"
 	}
 }

--- a/src/exportTypes/recordFieldUnified.ts
+++ b/src/exportTypes/recordFieldUnified.ts
@@ -1,0 +1,1 @@
+export type { kintoneRecordFieldUnified } from "../types/recordFieldUnified";

--- a/src/functions/record.ts
+++ b/src/functions/record.ts
@@ -2,321 +2,276 @@ import type { KintoneRecordField } from "@kintone/rest-api-client";
 import type { kintoneRecordFieldEvent } from "../exportTypes/recordFieldEvent";
 import type { kintoneRecordFieldGet } from "../exportTypes/recordFieldGet";
 import type { kintoneRecordFieldSet } from "../exportTypes/recordFieldSet";
-import type { kintoneRecordFieldUnified } from "../exportTypes/recordFieldUnified";
 
 type F<A, B> = A extends B ? B : A;
 type FFF<A, B, C, D> = F<A, F<B, F<C, F<D, never>>>>;
-type FFFF<A, B, C, D, E> = F<A, F<B, F<C, F<D, F<E, never>>>>>;
 
-/** すべてのフィールド型のユニオン（5つのコンテキストに対応） */
+/**
+ * すべてのフィールド型のユニオン（4つのコンテキストに対応）
+ * kintoneRecordFieldUnifiedはKintoneRecordFieldと同一のため含まない
+ */
 type AllFieldTypes =
 	| KintoneRecordField.OneOf
 	| kintoneRecordFieldGet.OneOf
 	| kintoneRecordFieldSet.OneOf
-	| kintoneRecordFieldEvent.OneOf
-	| kintoneRecordFieldUnified.OneOf;
+	| kintoneRecordFieldEvent.OneOf;
 
 const isRecordNumber = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.RecordNumber,
 	kintoneRecordFieldGet.RecordNumber,
-	kintoneRecordFieldSet.RecordNumber,
 	kintoneRecordFieldEvent.RecordNumber,
-	kintoneRecordFieldUnified.RecordNumber
+	kintoneRecordFieldSet.RecordNumber
 > => field.type === "RECORD_NUMBER";
 
 const isCreator = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Creator,
 	kintoneRecordFieldGet.Creator,
-	kintoneRecordFieldSet.Creator,
 	kintoneRecordFieldEvent.Creator,
-	kintoneRecordFieldUnified.Creator
+	kintoneRecordFieldSet.Creator
 > => field.type === "CREATOR";
 
 const isCreatedTime = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.CreatedTime,
 	kintoneRecordFieldGet.CreatedTime,
-	kintoneRecordFieldSet.CreatedTime,
 	kintoneRecordFieldEvent.CreatedTime,
-	kintoneRecordFieldUnified.CreatedTime
+	kintoneRecordFieldSet.CreatedTime
 > => field.type === "CREATED_TIME";
 
 const isModifier = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Modifier,
 	kintoneRecordFieldGet.Modifier,
-	kintoneRecordFieldSet.Modifier,
 	kintoneRecordFieldEvent.Modifier,
-	kintoneRecordFieldUnified.Modifier
+	kintoneRecordFieldSet.Modifier
 > => field.type === "MODIFIER";
 
 const isUpdatedTime = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.UpdatedTime,
 	kintoneRecordFieldGet.UpdatedTime,
-	kintoneRecordFieldSet.UpdatedTime,
 	kintoneRecordFieldEvent.UpdatedTime,
-	kintoneRecordFieldUnified.UpdatedTime
+	kintoneRecordFieldSet.UpdatedTime
 > => field.type === "UPDATED_TIME";
 
 const isSingleLineText = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.SingleLineText,
 	kintoneRecordFieldGet.SingleLineText,
-	kintoneRecordFieldSet.SingleLineText,
 	kintoneRecordFieldEvent.SingleLineText,
-	kintoneRecordFieldUnified.SingleLineText
+	kintoneRecordFieldSet.SingleLineText
 > => field.type === "SINGLE_LINE_TEXT";
 
 const isMultiLineText = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.MultiLineText,
 	kintoneRecordFieldGet.MultiLineText,
-	kintoneRecordFieldSet.MultiLineText,
 	kintoneRecordFieldEvent.MultiLineText,
-	kintoneRecordFieldUnified.MultiLineText
+	kintoneRecordFieldSet.MultiLineText
 > => field.type === "MULTI_LINE_TEXT";
 
 const isRichText = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.RichText,
 	kintoneRecordFieldGet.RichText,
-	kintoneRecordFieldSet.RichText,
 	kintoneRecordFieldEvent.RichText,
-	kintoneRecordFieldUnified.RichText
+	kintoneRecordFieldSet.RichText
 > => field.type === "RICH_TEXT";
 
 const isNumber = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Number,
 	kintoneRecordFieldGet.Number,
-	kintoneRecordFieldSet.Number,
 	kintoneRecordFieldEvent.Number,
-	kintoneRecordFieldUnified.Number
+	kintoneRecordFieldSet.Number
 > => field.type === "NUMBER";
 
 const isCalc = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Calc,
 	kintoneRecordFieldGet.Calc,
-	kintoneRecordFieldSet.Calc,
 	kintoneRecordFieldEvent.Calc,
-	kintoneRecordFieldUnified.Calc
+	kintoneRecordFieldSet.Calc
 > => field.type === "CALC";
 
 const isCheckBox = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.CheckBox,
 	kintoneRecordFieldGet.CheckBox,
-	kintoneRecordFieldSet.CheckBox,
 	kintoneRecordFieldEvent.CheckBox,
-	kintoneRecordFieldUnified.CheckBox
+	kintoneRecordFieldSet.CheckBox
 > => field.type === "CHECK_BOX";
 
 const isRadioButton = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.RadioButton,
 	kintoneRecordFieldGet.RadioButton,
-	kintoneRecordFieldSet.RadioButton,
 	kintoneRecordFieldEvent.RadioButton,
-	kintoneRecordFieldUnified.RadioButton
+	kintoneRecordFieldSet.RadioButton
 > => field.type === "RADIO_BUTTON";
 
 const isMultiSelect = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.MultiSelect,
 	kintoneRecordFieldGet.MultiSelect,
-	kintoneRecordFieldSet.MultiSelect,
 	kintoneRecordFieldEvent.MultiSelect,
-	kintoneRecordFieldUnified.MultiSelect
+	kintoneRecordFieldSet.MultiSelect
 > => field.type === "MULTI_SELECT";
 
 const isDropDown = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Dropdown,
 	kintoneRecordFieldGet.Dropdown,
-	kintoneRecordFieldSet.Dropdown,
 	kintoneRecordFieldEvent.Dropdown,
-	kintoneRecordFieldUnified.Dropdown
+	kintoneRecordFieldSet.Dropdown
 > => field.type === "DROP_DOWN";
 
 const isUserSelect = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.UserSelect,
 	kintoneRecordFieldGet.UserSelect,
-	kintoneRecordFieldSet.UserSelect,
 	kintoneRecordFieldEvent.UserSelect,
-	kintoneRecordFieldUnified.UserSelect
+	kintoneRecordFieldSet.UserSelect
 > => field.type === "USER_SELECT";
 
 const isOrganizationSelect = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.OrganizationSelect,
 	kintoneRecordFieldGet.OrganizationSelect,
-	kintoneRecordFieldSet.OrganizationSelect,
 	kintoneRecordFieldEvent.OrganizationSelect,
-	kintoneRecordFieldUnified.OrganizationSelect
+	kintoneRecordFieldSet.OrganizationSelect
 > => field.type === "ORGANIZATION_SELECT";
 
 const isGroupSelect = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.GroupSelect,
 	kintoneRecordFieldGet.GroupSelect,
-	kintoneRecordFieldSet.GroupSelect,
 	kintoneRecordFieldEvent.GroupSelect,
-	kintoneRecordFieldUnified.GroupSelect
+	kintoneRecordFieldSet.GroupSelect
 > => field.type === "GROUP_SELECT";
 
 const isDate = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Date,
 	kintoneRecordFieldGet.Date,
-	kintoneRecordFieldSet.Date,
 	kintoneRecordFieldEvent.Date,
-	kintoneRecordFieldUnified.Date
+	kintoneRecordFieldSet.Date
 > => field.type === "DATE";
 
 const isTime = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Time,
 	kintoneRecordFieldGet.Time,
-	kintoneRecordFieldSet.Time,
 	kintoneRecordFieldEvent.Time,
-	kintoneRecordFieldUnified.Time
+	kintoneRecordFieldSet.Time
 > => field.type === "TIME";
 
 const isDatetime = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.DateTime,
 	kintoneRecordFieldGet.DateTime,
-	kintoneRecordFieldSet.DateTime,
 	kintoneRecordFieldEvent.DateTime,
-	kintoneRecordFieldUnified.DateTime
+	kintoneRecordFieldSet.DateTime
 > => field.type === "DATETIME";
 
 const isLink = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Link,
 	kintoneRecordFieldGet.Link,
-	kintoneRecordFieldSet.Link,
 	kintoneRecordFieldEvent.Link,
-	kintoneRecordFieldUnified.Link
+	kintoneRecordFieldSet.Link
 > => field.type === "LINK";
 
 const isFile = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.File,
 	kintoneRecordFieldGet.File,
-	kintoneRecordFieldSet.File,
 	kintoneRecordFieldEvent.File,
-	kintoneRecordFieldUnified.File
+	kintoneRecordFieldSet.File
 > => field.type === "FILE";
 
 const isSubtable = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Subtable<{
 		[fieldCode: string]: KintoneRecordField.InSubtable;
 	}>,
-	{
-		type: "SUBTABLE";
-		value: {
-			id: string;
-			value: { [fieldCode: string]: kintoneRecordFieldGet.InSubtable };
-		}[];
-	},
-	{
-		type: "SUBTABLE";
-		value: {
-			id?: string;
-			value: { [fieldCode: string]: kintoneRecordFieldSet.InSubtable };
-		}[];
-	},
-	{
-		type: "SUBTABLE";
-		value: {
-			id: string;
-			value: { [fieldCode: string]: kintoneRecordFieldEvent.InSubtable };
-		}[];
-	},
-	kintoneRecordFieldUnified.Subtable
+	kintoneRecordFieldGet.Subtable,
+	kintoneRecordFieldEvent.Subtable,
+	kintoneRecordFieldSet.Subtable
 > => field.type === "SUBTABLE";
 
 const isCategory = (
 	field: AllFieldTypes,
-): field is FFFF<
+): field is FFF<
 	KintoneRecordField.Category,
 	kintoneRecordFieldGet.Category,
-	kintoneRecordFieldSet.Category,
 	kintoneRecordFieldEvent.Category,
-	kintoneRecordFieldUnified.Category
+	kintoneRecordFieldSet.Category
 > => field.type === "CATEGORY";
 
 /** isStatus/isStatusAssignee/isID/isRevision は Set には存在しないため、Setを除く型に対応 */
 type AllFieldTypesWithoutSet =
 	| KintoneRecordField.OneOf
 	| kintoneRecordFieldGet.OneOf
-	| kintoneRecordFieldEvent.OneOf
-	| kintoneRecordFieldUnified.OneOf;
+	| kintoneRecordFieldEvent.OneOf;
+
+type FF<A, B, C> = F<A, F<B, F<C, never>>>;
 
 const isStatus = (
 	field: AllFieldTypesWithoutSet,
-): field is FFF<
+): field is FF<
 	KintoneRecordField.Status,
 	kintoneRecordFieldGet.Status,
-	kintoneRecordFieldEvent.Status,
-	kintoneRecordFieldUnified.Status
+	kintoneRecordFieldEvent.Status
 > => field.type === "STATUS";
 
 const isStatusAssignee = (
 	field: AllFieldTypesWithoutSet,
-): field is FFF<
+): field is FF<
 	KintoneRecordField.StatusAssignee,
 	kintoneRecordFieldGet.StatusAssignee,
-	kintoneRecordFieldEvent.StatusAssignee,
-	kintoneRecordFieldUnified.StatusAssignee
+	kintoneRecordFieldEvent.StatusAssignee
 > => field.type === "STATUS_ASSIGNEE";
 
 const isID = (
 	field: AllFieldTypesWithoutSet,
-): field is FFF<
+): field is FF<
 	KintoneRecordField.ID,
 	kintoneRecordFieldGet.ID,
-	kintoneRecordFieldEvent.ID,
-	kintoneRecordFieldUnified.ID
+	kintoneRecordFieldEvent.ID
 > => field.type === "__ID__";
 
 const isRevision = (
 	field: AllFieldTypesWithoutSet,
-): field is FFF<
+): field is FF<
 	KintoneRecordField.Revision,
 	kintoneRecordFieldGet.Revision,
-	kintoneRecordFieldEvent.Revision,
-	kintoneRecordFieldUnified.Revision
+	kintoneRecordFieldEvent.Revision
 > => field.type === "__REVISION__";
 
 export {

--- a/src/functions/record.ts
+++ b/src/functions/record.ts
@@ -2,279 +2,243 @@ import type { KintoneRecordField } from "@kintone/rest-api-client";
 import type { kintoneRecordFieldEvent } from "../exportTypes/recordFieldEvent";
 import type { kintoneRecordFieldGet } from "../exportTypes/recordFieldGet";
 import type { kintoneRecordFieldSet } from "../exportTypes/recordFieldSet";
+import type { kintoneRecordFieldUnified } from "../exportTypes/recordFieldUnified";
 
 type F<A, B> = A extends B ? B : A;
-type FF<A, B, C> = F<A, F<B, F<C, never>>>;
 type FFF<A, B, C, D> = F<A, F<B, F<C, F<D, never>>>>;
+type FFFF<A, B, C, D, E> = F<A, F<B, F<C, F<D, F<E, never>>>>>;
+
+/** すべてのフィールド型のユニオン（5つのコンテキストに対応） */
+type AllFieldTypes =
+	| KintoneRecordField.OneOf
+	| kintoneRecordFieldGet.OneOf
+	| kintoneRecordFieldSet.OneOf
+	| kintoneRecordFieldEvent.OneOf
+	| kintoneRecordFieldUnified.OneOf;
 
 const isRecordNumber = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.RecordNumber,
 	kintoneRecordFieldGet.RecordNumber,
 	kintoneRecordFieldSet.RecordNumber,
-	kintoneRecordFieldEvent.RecordNumber
+	kintoneRecordFieldEvent.RecordNumber,
+	kintoneRecordFieldUnified.RecordNumber
 > => field.type === "RECORD_NUMBER";
+
 const isCreator = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Creator,
 	kintoneRecordFieldGet.Creator,
 	kintoneRecordFieldSet.Creator,
-	kintoneRecordFieldEvent.Creator
+	kintoneRecordFieldEvent.Creator,
+	kintoneRecordFieldUnified.Creator
 > => field.type === "CREATOR";
+
 const isCreatedTime = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is
-	| KintoneRecordField.CreatedTime
-	| kintoneRecordFieldGet.CreatedTime
-	| kintoneRecordFieldSet.CreatedTime
-	| kintoneRecordFieldEvent.CreatedTime => field.type === "CREATED_TIME";
+	field: AllFieldTypes,
+): field is FFFF<
+	KintoneRecordField.CreatedTime,
+	kintoneRecordFieldGet.CreatedTime,
+	kintoneRecordFieldSet.CreatedTime,
+	kintoneRecordFieldEvent.CreatedTime,
+	kintoneRecordFieldUnified.CreatedTime
+> => field.type === "CREATED_TIME";
+
 const isModifier = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is
-	| KintoneRecordField.Modifier
-	| kintoneRecordFieldGet.Modifier
-	| kintoneRecordFieldSet.Modifier
-	| kintoneRecordFieldEvent.Modifier => field.type === "MODIFIER";
+	field: AllFieldTypes,
+): field is FFFF<
+	KintoneRecordField.Modifier,
+	kintoneRecordFieldGet.Modifier,
+	kintoneRecordFieldSet.Modifier,
+	kintoneRecordFieldEvent.Modifier,
+	kintoneRecordFieldUnified.Modifier
+> => field.type === "MODIFIER";
+
 const isUpdatedTime = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is
-	| KintoneRecordField.UpdatedTime
-	| kintoneRecordFieldGet.UpdatedTime
-	| kintoneRecordFieldSet.UpdatedTime
-	| kintoneRecordFieldEvent.UpdatedTime => field.type === "UPDATED_TIME";
+	field: AllFieldTypes,
+): field is FFFF<
+	KintoneRecordField.UpdatedTime,
+	kintoneRecordFieldGet.UpdatedTime,
+	kintoneRecordFieldSet.UpdatedTime,
+	kintoneRecordFieldEvent.UpdatedTime,
+	kintoneRecordFieldUnified.UpdatedTime
+> => field.type === "UPDATED_TIME";
+
 const isSingleLineText = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.SingleLineText,
 	kintoneRecordFieldGet.SingleLineText,
+	kintoneRecordFieldSet.SingleLineText,
 	kintoneRecordFieldEvent.SingleLineText,
-	kintoneRecordFieldSet.SingleLineText
+	kintoneRecordFieldUnified.SingleLineText
 > => field.type === "SINGLE_LINE_TEXT";
+
 const isMultiLineText = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.MultiLineText,
 	kintoneRecordFieldGet.MultiLineText,
 	kintoneRecordFieldSet.MultiLineText,
-	kintoneRecordFieldEvent.MultiLineText
+	kintoneRecordFieldEvent.MultiLineText,
+	kintoneRecordFieldUnified.MultiLineText
 > => field.type === "MULTI_LINE_TEXT";
+
 const isRichText = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.RichText,
 	kintoneRecordFieldGet.RichText,
 	kintoneRecordFieldSet.RichText,
-	kintoneRecordFieldEvent.RichText
+	kintoneRecordFieldEvent.RichText,
+	kintoneRecordFieldUnified.RichText
 > => field.type === "RICH_TEXT";
+
 const isNumber = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Number,
 	kintoneRecordFieldGet.Number,
 	kintoneRecordFieldSet.Number,
-	kintoneRecordFieldEvent.Number
+	kintoneRecordFieldEvent.Number,
+	kintoneRecordFieldUnified.Number
 > => field.type === "NUMBER";
+
 const isCalc = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Calc,
 	kintoneRecordFieldGet.Calc,
 	kintoneRecordFieldSet.Calc,
-	kintoneRecordFieldEvent.Calc
+	kintoneRecordFieldEvent.Calc,
+	kintoneRecordFieldUnified.Calc
 > => field.type === "CALC";
+
 const isCheckBox = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.CheckBox,
 	kintoneRecordFieldGet.CheckBox,
 	kintoneRecordFieldSet.CheckBox,
-	kintoneRecordFieldEvent.CheckBox
+	kintoneRecordFieldEvent.CheckBox,
+	kintoneRecordFieldUnified.CheckBox
 > => field.type === "CHECK_BOX";
+
 const isRadioButton = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.RadioButton,
 	kintoneRecordFieldGet.RadioButton,
 	kintoneRecordFieldSet.RadioButton,
-	kintoneRecordFieldEvent.RadioButton
+	kintoneRecordFieldEvent.RadioButton,
+	kintoneRecordFieldUnified.RadioButton
 > => field.type === "RADIO_BUTTON";
+
 const isMultiSelect = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.MultiSelect,
 	kintoneRecordFieldGet.MultiSelect,
 	kintoneRecordFieldSet.MultiSelect,
-	kintoneRecordFieldEvent.MultiSelect
+	kintoneRecordFieldEvent.MultiSelect,
+	kintoneRecordFieldUnified.MultiSelect
 > => field.type === "MULTI_SELECT";
+
 const isDropDown = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Dropdown,
 	kintoneRecordFieldGet.Dropdown,
 	kintoneRecordFieldSet.Dropdown,
-	kintoneRecordFieldEvent.Dropdown
+	kintoneRecordFieldEvent.Dropdown,
+	kintoneRecordFieldUnified.Dropdown
 > => field.type === "DROP_DOWN";
+
 const isUserSelect = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.UserSelect,
 	kintoneRecordFieldGet.UserSelect,
 	kintoneRecordFieldSet.UserSelect,
-	kintoneRecordFieldEvent.UserSelect
+	kintoneRecordFieldEvent.UserSelect,
+	kintoneRecordFieldUnified.UserSelect
 > => field.type === "USER_SELECT";
+
 const isOrganizationSelect = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.OrganizationSelect,
 	kintoneRecordFieldGet.OrganizationSelect,
 	kintoneRecordFieldSet.OrganizationSelect,
-	kintoneRecordFieldEvent.OrganizationSelect
+	kintoneRecordFieldEvent.OrganizationSelect,
+	kintoneRecordFieldUnified.OrganizationSelect
 > => field.type === "ORGANIZATION_SELECT";
+
 const isGroupSelect = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.GroupSelect,
 	kintoneRecordFieldGet.GroupSelect,
 	kintoneRecordFieldSet.GroupSelect,
-	kintoneRecordFieldEvent.GroupSelect
+	kintoneRecordFieldEvent.GroupSelect,
+	kintoneRecordFieldUnified.GroupSelect
 > => field.type === "GROUP_SELECT";
+
 const isDate = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Date,
 	kintoneRecordFieldGet.Date,
 	kintoneRecordFieldSet.Date,
-	kintoneRecordFieldEvent.Date
+	kintoneRecordFieldEvent.Date,
+	kintoneRecordFieldUnified.Date
 > => field.type === "DATE";
+
 const isTime = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Time,
 	kintoneRecordFieldGet.Time,
 	kintoneRecordFieldSet.Time,
-	kintoneRecordFieldEvent.Time
+	kintoneRecordFieldEvent.Time,
+	kintoneRecordFieldUnified.Time
 > => field.type === "TIME";
+
 const isDatetime = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.DateTime,
 	kintoneRecordFieldGet.DateTime,
 	kintoneRecordFieldSet.DateTime,
-	kintoneRecordFieldEvent.DateTime
+	kintoneRecordFieldEvent.DateTime,
+	kintoneRecordFieldUnified.DateTime
 > => field.type === "DATETIME";
+
 const isLink = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Link,
 	kintoneRecordFieldGet.Link,
 	kintoneRecordFieldSet.Link,
-	kintoneRecordFieldEvent.Link
+	kintoneRecordFieldEvent.Link,
+	kintoneRecordFieldUnified.Link
 > => field.type === "LINK";
+
 const isFile = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.File,
 	kintoneRecordFieldGet.File,
 	kintoneRecordFieldSet.File,
-	kintoneRecordFieldEvent.File
+	kintoneRecordFieldEvent.File,
+	kintoneRecordFieldUnified.File
 > => field.type === "FILE";
+
 const isSubtable = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Subtable<{
 		[fieldCode: string]: KintoneRecordField.InSubtable;
 	}>,
@@ -298,67 +262,61 @@ const isSubtable = (
 			id: string;
 			value: { [fieldCode: string]: kintoneRecordFieldEvent.InSubtable };
 		}[];
-	}
+	},
+	kintoneRecordFieldUnified.Subtable
 > => field.type === "SUBTABLE";
+
 const isCategory = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		| kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FFF<
+	field: AllFieldTypes,
+): field is FFFF<
 	KintoneRecordField.Category,
 	kintoneRecordFieldGet.Category,
 	kintoneRecordFieldSet.Category,
-	kintoneRecordFieldEvent.Category
+	kintoneRecordFieldEvent.Category,
+	kintoneRecordFieldUnified.Category
 > => field.type === "CATEGORY";
+
+/** isStatus/isStatusAssignee/isID/isRevision は Set には存在しないため、Setを除く型に対応 */
+type AllFieldTypesWithoutSet =
+	| KintoneRecordField.OneOf
+	| kintoneRecordFieldGet.OneOf
+	| kintoneRecordFieldEvent.OneOf
+	| kintoneRecordFieldUnified.OneOf;
+
 const isStatus = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		// | kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FF<
+	field: AllFieldTypesWithoutSet,
+): field is FFF<
 	KintoneRecordField.Status,
 	kintoneRecordFieldGet.Status,
-	// kintoneRecordFieldSet.Status,
-	kintoneRecordFieldEvent.Status
+	kintoneRecordFieldEvent.Status,
+	kintoneRecordFieldUnified.Status
 > => field.type === "STATUS";
+
 const isStatusAssignee = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		// | kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FF<
+	field: AllFieldTypesWithoutSet,
+): field is FFF<
 	KintoneRecordField.StatusAssignee,
 	kintoneRecordFieldGet.StatusAssignee,
-	// kintoneRecordFieldSet.StatusAssignee,
-	kintoneRecordFieldEvent.StatusAssignee
+	kintoneRecordFieldEvent.StatusAssignee,
+	kintoneRecordFieldUnified.StatusAssignee
 > => field.type === "STATUS_ASSIGNEE";
+
 const isID = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		// | kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FF<
+	field: AllFieldTypesWithoutSet,
+): field is FFF<
 	KintoneRecordField.ID,
 	kintoneRecordFieldGet.ID,
-	// kintoneRecordFieldSet.ID,
-	kintoneRecordFieldEvent.ID
+	kintoneRecordFieldEvent.ID,
+	kintoneRecordFieldUnified.ID
 > => field.type === "__ID__";
+
 const isRevision = (
-	field:
-		| KintoneRecordField.OneOf
-		| kintoneRecordFieldGet.OneOf
-		// | kintoneRecordFieldSet.OneOf
-		| kintoneRecordFieldEvent.OneOf,
-): field is FF<
+	field: AllFieldTypesWithoutSet,
+): field is FFF<
 	KintoneRecordField.Revision,
 	kintoneRecordFieldGet.Revision,
-	// kintoneRecordFieldSet.Revision,
-	kintoneRecordFieldEvent.Revision
+	kintoneRecordFieldEvent.Revision,
+	kintoneRecordFieldUnified.Revision
 > => field.type === "__REVISION__";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { kintoneRecordFieldEvent } from "./exportTypes/recordFieldEvent";
 import type { kintoneRecordFieldGet } from "./exportTypes/recordFieldGet";
 import type { kintoneRecordFieldSet } from "./exportTypes/recordFieldSet";
+import type { kintoneRecordFieldUnified } from "./exportTypes/recordFieldUnified";
 import * as guardFormField from "./functions/formField";
 import * as guardFormLayout from "./functions/formLayout";
 import * as guardRecord from "./functions/record";
@@ -11,4 +12,5 @@ export type {
 	kintoneRecordFieldGet,
 	kintoneRecordFieldSet,
 	kintoneRecordFieldEvent,
+	kintoneRecordFieldUnified,
 };

--- a/src/types/recordFieldEvent.ts
+++ b/src/types/recordFieldEvent.ts
@@ -111,14 +111,14 @@ namespace kintoneRecordFieldEvent {
 
 	export interface Date {
 		type: "DATE";
-		value: string;
+		value: string | null;
 		disabled?: boolean;
 		error?: string | null;
 	}
 
 	export interface Time {
 		type: "TIME";
-		value: string;
+		value: string | null;
 		disabled?: boolean;
 		error?: string | null;
 	}

--- a/src/types/recordFieldGet.ts
+++ b/src/types/recordFieldGet.ts
@@ -86,12 +86,12 @@ namespace kintoneRecordFieldGet {
 
 	export interface Date {
 		type: "DATE";
-		value: string;
+		value: string | null;
 	}
 
 	export interface Time {
 		type: "TIME";
-		value: string;
+		value: string | null;
 	}
 
 	export interface DateTime {

--- a/src/types/recordFieldSet.ts
+++ b/src/types/recordFieldSet.ts
@@ -86,12 +86,12 @@ namespace kintoneRecordFieldSet {
 
 	export interface Date {
 		type: "DATE";
-		value: string;
+		value: string | null;
 	}
 
 	export interface Time {
 		type: "TIME";
-		value: string;
+		value: string | null;
 	}
 
 	export interface DateTime {

--- a/src/types/recordFieldUnified.ts
+++ b/src/types/recordFieldUnified.ts
@@ -3,22 +3,58 @@ import type { KintoneRecordField } from "@kintone/rest-api-client";
 /**
  * kintoneの4つのコンテキスト（Event/Get/Set/REST API）で統一的に使用できるフィールド型
  *
- * この型は以下のすべてと互換性があります：
- * - kintoneRecordFieldEvent: JavaScriptイベント（app.record.detail.showなど）
- * - kintoneRecordFieldGet: レコード取得時
- * - kintoneRecordFieldSet: レコード設定時
- * - KintoneRecordField (@kintone/rest-api-client): REST API操作
+ * この型は@kintone/rest-api-clientのKintoneRecordFieldを再エクスポートし、
+ * 追加のユーティリティ型を提供します。
  *
  * asキャストなしで@kintone/rest-api-clientに渡すことができます。
  */
 namespace kintoneRecordFieldUnified {
+	// ===== @kintone/rest-api-clientからの再エクスポート =====
+
+	export type ID = KintoneRecordField.ID;
+	export type Revision = KintoneRecordField.Revision;
+	export type RecordNumber = KintoneRecordField.RecordNumber;
+	export type Creator = KintoneRecordField.Creator;
+	export type CreatedTime = KintoneRecordField.CreatedTime;
+	export type Modifier = KintoneRecordField.Modifier;
+	export type UpdatedTime = KintoneRecordField.UpdatedTime;
+	export type SingleLineText = KintoneRecordField.SingleLineText;
+	export type Number = KintoneRecordField.Number;
+	export type Calc = KintoneRecordField.Calc;
+	export type MultiLineText = KintoneRecordField.MultiLineText;
+	export type RichText = KintoneRecordField.RichText;
+	export type Link = KintoneRecordField.Link;
+	export type CheckBox = KintoneRecordField.CheckBox;
+	export type RadioButton = KintoneRecordField.RadioButton;
+	export type Dropdown = KintoneRecordField.Dropdown;
+	export type MultiSelect = KintoneRecordField.MultiSelect;
+	export type File = KintoneRecordField.File;
+	export type Date = KintoneRecordField.Date;
+	export type Time = KintoneRecordField.Time;
+	export type DateTime = KintoneRecordField.DateTime;
+	export type UserSelect = KintoneRecordField.UserSelect;
+	export type OrganizationSelect = KintoneRecordField.OrganizationSelect;
+	export type GroupSelect = KintoneRecordField.GroupSelect;
+	export type Category = KintoneRecordField.Category;
+	export type Status = KintoneRecordField.Status;
+	export type StatusAssignee = KintoneRecordField.StatusAssignee;
+	export type InSubtable = KintoneRecordField.InSubtable;
+	export type Subtable<
+		T extends { [fieldCode: string]: InSubtable } = {
+			[fieldCode: string]: InSubtable;
+		},
+	> = KintoneRecordField.Subtable<T>;
+	export type OneOf = KintoneRecordField.OneOf;
+
+	// ===== ユーティリティ型 =====
+
 	/** ユーザー/組織/グループの共通エンティティ型 */
 	export interface Entity {
 		code: string;
 		name: string;
 	}
 
-	/** ファイル情報（取得時・イベント時） */
+	/** ファイル情報 */
 	export interface FileInformation {
 		contentType: string;
 		fileKey: string;
@@ -26,352 +62,13 @@ namespace kintoneRecordFieldUnified {
 		size: string;
 	}
 
-	/** ファイル情報（設定時） */
-	export interface FileInformationForSet {
-		fileKey: string;
-	}
-
-	// ===== システムフィールド（読み取り専用） =====
-
-	export interface RecordNumber {
-		type: "RECORD_NUMBER";
-		value: string;
-	}
-
-	export interface Creator {
-		type: "CREATOR";
-		value: Entity;
-	}
-
-	export interface CreatedTime {
-		type: "CREATED_TIME";
-		value: string;
-	}
-
-	export interface Modifier {
-		type: "MODIFIER";
-		value: Entity;
-	}
-
-	export interface UpdatedTime {
-		type: "UPDATED_TIME";
-		value: string;
-	}
-
-	export interface ID {
-		type: "__ID__";
-		value: string;
-	}
-
-	export interface Revision {
-		type: "__REVISION__";
-		value: string;
-	}
-
-	// ===== テキスト系フィールド =====
-
-	export interface SingleLineText {
-		type: "SINGLE_LINE_TEXT";
-		value: string;
-	}
-
-	export interface MultiLineText {
-		type: "MULTI_LINE_TEXT";
-		value: string;
-	}
-
-	export interface RichText {
-		type: "RICH_TEXT";
-		value: string;
-	}
-
-	export interface Link {
-		type: "LINK";
-		value: string;
-	}
-
-	// ===== 数値・計算フィールド =====
-
-	export interface Number {
-		type: "NUMBER";
-		value: string;
-	}
-
-	export interface Calc {
-		type: "CALC";
-		value: string;
-	}
-
-	// ===== 選択系フィールド =====
-
-	export interface CheckBox {
-		type: "CHECK_BOX";
-		value: string[];
-	}
-
-	export interface RadioButton {
-		type: "RADIO_BUTTON";
-		value: string;
-	}
-
-	export interface MultiSelect {
-		type: "MULTI_SELECT";
-		value: string[];
-	}
-
-	/**
-	 * ドロップダウン
-	 * @kintone/rest-api-clientと互換性を持たせるため string | null
-	 */
-	export interface Dropdown {
-		type: "DROP_DOWN";
-		value: string | null;
-	}
-
-	// ===== ユーザー選択系フィールド =====
-
-	export interface UserSelect {
-		type: "USER_SELECT";
-		value: Entity[];
-	}
-
-	export interface OrganizationSelect {
-		type: "ORGANIZATION_SELECT";
-		value: Entity[];
-	}
-
-	export interface GroupSelect {
-		type: "GROUP_SELECT";
-		value: Entity[];
-	}
-
-	// ===== 日時系フィールド =====
-
-	/**
-	 * 日付フィールド
-	 * @kintone/rest-api-clientと互換性を持たせるため string | null
-	 */
-	export interface Date {
-		type: "DATE";
-		value: string | null;
-	}
-
-	/**
-	 * 時刻フィールド
-	 * @kintone/rest-api-clientと互換性を持たせるため string | null
-	 */
-	export interface Time {
-		type: "TIME";
-		value: string | null;
-	}
-
-	export interface DateTime {
-		type: "DATETIME";
-		value: string;
-	}
-
-	// ===== ファイルフィールド =====
-
-	/**
-	 * ファイルフィールド（取得時）
-	 * FileInformation配列を持つ
-	 */
-	export interface File {
-		type: "FILE";
-		value: FileInformation[];
-	}
-
-	/**
-	 * ファイルフィールド（設定時）
-	 * fileKeyのみを持つ
-	 */
-	export interface FileForSet {
-		type: "FILE";
-		value: FileInformationForSet[];
-	}
-
-	// ===== サブテーブル =====
-
-	/** サブテーブル内で使用可能なフィールド型 */
-	export type InSubtable =
-		| SingleLineText
-		| Number
-		| Calc
-		| MultiLineText
-		| RichText
-		| Link
-		| CheckBox
-		| RadioButton
-		| Dropdown
-		| MultiSelect
-		| File
-		| Date
-		| Time
-		| DateTime
-		| UserSelect
-		| OrganizationSelect
-		| GroupSelect;
-
-	/** サブテーブル内で使用可能なフィールド型（設定時） */
-	export type InSubtableForSet =
-		| SingleLineText
-		| Number
-		| Calc
-		| MultiLineText
-		| RichText
-		| Link
-		| CheckBox
-		| RadioButton
-		| Dropdown
-		| MultiSelect
-		| FileForSet
-		| Date
-		| Time
-		| DateTime
-		| UserSelect
-		| OrganizationSelect
-		| GroupSelect;
-
-	/** サブテーブル行 */
-	export interface SubtableRow<
-		T extends { [fieldCode: string]: InSubtable } = {
-			[fieldCode: string]: InSubtable;
-		},
-	> {
-		id: string;
-		value: T;
-	}
-
-	/** サブテーブル行（設定時、idはオプショナル） */
-	export interface SubtableRowForSet<
-		T extends { [fieldCode: string]: InSubtableForSet } = {
-			[fieldCode: string]: InSubtableForSet;
-		},
-	> {
-		id?: string;
-		value: T;
-	}
-
-	export interface Subtable<
-		T extends { [fieldCode: string]: InSubtable } = {
-			[fieldCode: string]: InSubtable;
-		},
-	> {
-		type: "SUBTABLE";
-		value: SubtableRow<T>[];
-	}
-
-	export interface SubtableForSet<
-		T extends { [fieldCode: string]: InSubtableForSet } = {
-			[fieldCode: string]: InSubtableForSet;
-		},
-	> {
-		type: "SUBTABLE";
-		value: SubtableRowForSet<T>[];
-	}
-
-	// ===== プロセス管理系フィールド =====
-
-	export interface Category {
-		type: "CATEGORY";
-		value: string[];
-	}
-
-	export interface Status {
-		type: "STATUS";
-		value: string;
-	}
-
-	export interface StatusAssignee {
-		type: "STATUS_ASSIGNEE";
-		value: Entity[];
-	}
-
-	// ===== 統合型 =====
-
-	/** すべてのフィールド型のユニオン（取得・参照用） */
-	export type OneOf =
-		| RecordNumber
-		| Creator
-		| CreatedTime
-		| Modifier
-		| UpdatedTime
-		| ID
-		| Revision
-		| SingleLineText
-		| MultiLineText
-		| RichText
-		| Link
-		| Number
-		| Calc
-		| CheckBox
-		| RadioButton
-		| MultiSelect
-		| Dropdown
-		| UserSelect
-		| OrganizationSelect
-		| GroupSelect
-		| Date
-		| Time
-		| DateTime
-		| File
-		| Subtable
-		| Category
-		| Status
-		| StatusAssignee;
-
-	/** 書き込み可能なフィールド型のユニオン（設定・登録・更新用） */
-	export type OneOfForSet =
-		| SingleLineText
-		| MultiLineText
-		| RichText
-		| Link
-		| Number
-		| CheckBox
-		| RadioButton
-		| MultiSelect
-		| Dropdown
-		| UserSelect
-		| OrganizationSelect
-		| GroupSelect
-		| Date
-		| Time
-		| DateTime
-		| FileForSet
-		| SubtableForSet;
-
-	/** レコード型（取得用） */
+	/** レコード型 */
 	export type Record = {
 		$id?: ID;
 		$revision?: Revision;
 	} & {
 		[fieldCode: string]: Exclude<OneOf, ID | Revision>;
 	};
-
-	/** レコード型（設定用） */
-	export type RecordForSet = {
-		[fieldCode: string]: OneOfForSet;
-	};
-
-	// ===== @kintone/rest-api-client互換型ヘルパー =====
-
-	/**
-	 * KintoneRecordField.OneOfに変換可能であることを保証する型
-	 * この型はKintoneRecordField.OneOfにasキャストなしで代入可能
-	 */
-	export type AsKintoneRecordField<T extends OneOf> = T extends File
-		? KintoneRecordField.File
-		: T extends Subtable<infer U>
-			? KintoneRecordField.Subtable<{
-					[K in keyof U]: U[K] extends InSubtable
-						? AsKintoneRecordFieldInSubtable<U[K]>
-						: never;
-				}>
-			: T;
-
-	type AsKintoneRecordFieldInSubtable<T extends InSubtable> = T extends File
-		? KintoneRecordField.File
-		: T;
 }
 
 export { kintoneRecordFieldUnified };

--- a/src/types/recordFieldUnified.ts
+++ b/src/types/recordFieldUnified.ts
@@ -1,0 +1,377 @@
+import type { KintoneRecordField } from "@kintone/rest-api-client";
+
+/**
+ * kintoneの4つのコンテキスト（Event/Get/Set/REST API）で統一的に使用できるフィールド型
+ *
+ * この型は以下のすべてと互換性があります：
+ * - kintoneRecordFieldEvent: JavaScriptイベント（app.record.detail.showなど）
+ * - kintoneRecordFieldGet: レコード取得時
+ * - kintoneRecordFieldSet: レコード設定時
+ * - KintoneRecordField (@kintone/rest-api-client): REST API操作
+ *
+ * asキャストなしで@kintone/rest-api-clientに渡すことができます。
+ */
+namespace kintoneRecordFieldUnified {
+	/** ユーザー/組織/グループの共通エンティティ型 */
+	export interface Entity {
+		code: string;
+		name: string;
+	}
+
+	/** ファイル情報（取得時・イベント時） */
+	export interface FileInformation {
+		contentType: string;
+		fileKey: string;
+		name: string;
+		size: string;
+	}
+
+	/** ファイル情報（設定時） */
+	export interface FileInformationForSet {
+		fileKey: string;
+	}
+
+	// ===== システムフィールド（読み取り専用） =====
+
+	export interface RecordNumber {
+		type: "RECORD_NUMBER";
+		value: string;
+	}
+
+	export interface Creator {
+		type: "CREATOR";
+		value: Entity;
+	}
+
+	export interface CreatedTime {
+		type: "CREATED_TIME";
+		value: string;
+	}
+
+	export interface Modifier {
+		type: "MODIFIER";
+		value: Entity;
+	}
+
+	export interface UpdatedTime {
+		type: "UPDATED_TIME";
+		value: string;
+	}
+
+	export interface ID {
+		type: "__ID__";
+		value: string;
+	}
+
+	export interface Revision {
+		type: "__REVISION__";
+		value: string;
+	}
+
+	// ===== テキスト系フィールド =====
+
+	export interface SingleLineText {
+		type: "SINGLE_LINE_TEXT";
+		value: string;
+	}
+
+	export interface MultiLineText {
+		type: "MULTI_LINE_TEXT";
+		value: string;
+	}
+
+	export interface RichText {
+		type: "RICH_TEXT";
+		value: string;
+	}
+
+	export interface Link {
+		type: "LINK";
+		value: string;
+	}
+
+	// ===== 数値・計算フィールド =====
+
+	export interface Number {
+		type: "NUMBER";
+		value: string;
+	}
+
+	export interface Calc {
+		type: "CALC";
+		value: string;
+	}
+
+	// ===== 選択系フィールド =====
+
+	export interface CheckBox {
+		type: "CHECK_BOX";
+		value: string[];
+	}
+
+	export interface RadioButton {
+		type: "RADIO_BUTTON";
+		value: string;
+	}
+
+	export interface MultiSelect {
+		type: "MULTI_SELECT";
+		value: string[];
+	}
+
+	/**
+	 * ドロップダウン
+	 * @kintone/rest-api-clientと互換性を持たせるため string | null
+	 */
+	export interface Dropdown {
+		type: "DROP_DOWN";
+		value: string | null;
+	}
+
+	// ===== ユーザー選択系フィールド =====
+
+	export interface UserSelect {
+		type: "USER_SELECT";
+		value: Entity[];
+	}
+
+	export interface OrganizationSelect {
+		type: "ORGANIZATION_SELECT";
+		value: Entity[];
+	}
+
+	export interface GroupSelect {
+		type: "GROUP_SELECT";
+		value: Entity[];
+	}
+
+	// ===== 日時系フィールド =====
+
+	/**
+	 * 日付フィールド
+	 * @kintone/rest-api-clientと互換性を持たせるため string | null
+	 */
+	export interface Date {
+		type: "DATE";
+		value: string | null;
+	}
+
+	/**
+	 * 時刻フィールド
+	 * @kintone/rest-api-clientと互換性を持たせるため string | null
+	 */
+	export interface Time {
+		type: "TIME";
+		value: string | null;
+	}
+
+	export interface DateTime {
+		type: "DATETIME";
+		value: string;
+	}
+
+	// ===== ファイルフィールド =====
+
+	/**
+	 * ファイルフィールド（取得時）
+	 * FileInformation配列を持つ
+	 */
+	export interface File {
+		type: "FILE";
+		value: FileInformation[];
+	}
+
+	/**
+	 * ファイルフィールド（設定時）
+	 * fileKeyのみを持つ
+	 */
+	export interface FileForSet {
+		type: "FILE";
+		value: FileInformationForSet[];
+	}
+
+	// ===== サブテーブル =====
+
+	/** サブテーブル内で使用可能なフィールド型 */
+	export type InSubtable =
+		| SingleLineText
+		| Number
+		| Calc
+		| MultiLineText
+		| RichText
+		| Link
+		| CheckBox
+		| RadioButton
+		| Dropdown
+		| MultiSelect
+		| File
+		| Date
+		| Time
+		| DateTime
+		| UserSelect
+		| OrganizationSelect
+		| GroupSelect;
+
+	/** サブテーブル内で使用可能なフィールド型（設定時） */
+	export type InSubtableForSet =
+		| SingleLineText
+		| Number
+		| Calc
+		| MultiLineText
+		| RichText
+		| Link
+		| CheckBox
+		| RadioButton
+		| Dropdown
+		| MultiSelect
+		| FileForSet
+		| Date
+		| Time
+		| DateTime
+		| UserSelect
+		| OrganizationSelect
+		| GroupSelect;
+
+	/** サブテーブル行 */
+	export interface SubtableRow<
+		T extends { [fieldCode: string]: InSubtable } = {
+			[fieldCode: string]: InSubtable;
+		},
+	> {
+		id: string;
+		value: T;
+	}
+
+	/** サブテーブル行（設定時、idはオプショナル） */
+	export interface SubtableRowForSet<
+		T extends { [fieldCode: string]: InSubtableForSet } = {
+			[fieldCode: string]: InSubtableForSet;
+		},
+	> {
+		id?: string;
+		value: T;
+	}
+
+	export interface Subtable<
+		T extends { [fieldCode: string]: InSubtable } = {
+			[fieldCode: string]: InSubtable;
+		},
+	> {
+		type: "SUBTABLE";
+		value: SubtableRow<T>[];
+	}
+
+	export interface SubtableForSet<
+		T extends { [fieldCode: string]: InSubtableForSet } = {
+			[fieldCode: string]: InSubtableForSet;
+		},
+	> {
+		type: "SUBTABLE";
+		value: SubtableRowForSet<T>[];
+	}
+
+	// ===== プロセス管理系フィールド =====
+
+	export interface Category {
+		type: "CATEGORY";
+		value: string[];
+	}
+
+	export interface Status {
+		type: "STATUS";
+		value: string;
+	}
+
+	export interface StatusAssignee {
+		type: "STATUS_ASSIGNEE";
+		value: Entity[];
+	}
+
+	// ===== 統合型 =====
+
+	/** すべてのフィールド型のユニオン（取得・参照用） */
+	export type OneOf =
+		| RecordNumber
+		| Creator
+		| CreatedTime
+		| Modifier
+		| UpdatedTime
+		| ID
+		| Revision
+		| SingleLineText
+		| MultiLineText
+		| RichText
+		| Link
+		| Number
+		| Calc
+		| CheckBox
+		| RadioButton
+		| MultiSelect
+		| Dropdown
+		| UserSelect
+		| OrganizationSelect
+		| GroupSelect
+		| Date
+		| Time
+		| DateTime
+		| File
+		| Subtable
+		| Category
+		| Status
+		| StatusAssignee;
+
+	/** 書き込み可能なフィールド型のユニオン（設定・登録・更新用） */
+	export type OneOfForSet =
+		| SingleLineText
+		| MultiLineText
+		| RichText
+		| Link
+		| Number
+		| CheckBox
+		| RadioButton
+		| MultiSelect
+		| Dropdown
+		| UserSelect
+		| OrganizationSelect
+		| GroupSelect
+		| Date
+		| Time
+		| DateTime
+		| FileForSet
+		| SubtableForSet;
+
+	/** レコード型（取得用） */
+	export type Record = {
+		$id?: ID;
+		$revision?: Revision;
+	} & {
+		[fieldCode: string]: Exclude<OneOf, ID | Revision>;
+	};
+
+	/** レコード型（設定用） */
+	export type RecordForSet = {
+		[fieldCode: string]: OneOfForSet;
+	};
+
+	// ===== @kintone/rest-api-client互換型ヘルパー =====
+
+	/**
+	 * KintoneRecordField.OneOfに変換可能であることを保証する型
+	 * この型はKintoneRecordField.OneOfにasキャストなしで代入可能
+	 */
+	export type AsKintoneRecordField<T extends OneOf> = T extends File
+		? KintoneRecordField.File
+		: T extends Subtable<infer U>
+			? KintoneRecordField.Subtable<{
+					[K in keyof U]: U[K] extends InSubtable
+						? AsKintoneRecordFieldInSubtable<U[K]>
+						: never;
+				}>
+			: T;
+
+	type AsKintoneRecordFieldInSubtable<T extends InSubtable> = T extends File
+		? KintoneRecordField.File
+		: T;
+}
+
+export { kintoneRecordFieldUnified };


### PR DESCRIPTION
## Summary
- Update `@kintone/rest-api-client` from `^6.0.0` to `^6.1.2`
- Update `dotenv` from `^17.2.3` to `^17.3.1`
- Update dev dependencies: `@biomejs/biome` 2.3.6 → 2.4.6, `@types/node` `^24.10.1` → `^25.4.0`, `rimraf` `^6.1.0` → `^6.1.3`, `vite` `^7.2.2` → `^7.3.1`, `vitest` `^4.0.10` → `^4.0.18`
- Add unified field types for `@kintone/rest-api-client` compatibility and simplify via re-exports

## Test plan
- [ ] Verify the package builds successfully after dependency updates
- [ ] Run tests to confirm no regressions from updated dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)