### PR TITLE
fix: update actions version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - name: Run Biome

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           release-type: node
       # The logic below handles the npm publication:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # these if statements ensure that a publication only occurs when
         # a new release is created:
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/setup-node` from v4 to v6
- Update Node.js version from 22 to 24 in release workflow

## Test plan
- [ ] Verify the release workflow runs successfully with the updated action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)