### PR TITLE
fix: separate publish workflow and simplify release-please config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish  

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,19 +17,3 @@ jobs:
         id: release
         with:
           release-type: node
-      # The logic below handles the npm publication:
-      - uses: actions/checkout@v6
-        # these if statements ensure that a publication only occurs when
-        # a new release is created:
-        if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- Move npm publish steps to a dedicated `publish.yml` workflow triggered by version tags (`v*`)
- Remove publication steps from `release-please.yml` to keep it focused on release PR management
- Add `npm run build` and `npm test` steps before publishing in the new workflow

## Test plan
- [ ] Verify release-please workflow still creates release PRs correctly
- [ ] Verify publish workflow triggers on version tags and publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)